### PR TITLE
feat: 新增 /厂商订阅 指令，群内一键开启/关闭厂商状态自动推送并持久化

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ OpenAI、Claude、Groq、Cohere、Moonshot AI、MiniMax、GitHub 和 Cloudflare 
    - aiocqhttp 群号：`123456789`
    - qq_official 群 openid：`E4BE1234ABCD5678`
    - 完整 UMO：`1:GroupMessage:123456789`
+
+   > 也可在目标群里用 `/厂商订阅 开` 让机器人自动把当前群 UMO 写入白名单（详见「命令 → 订阅开关」），无需手动复制 UMO。
+
 3. `platform_id`：仅对纯群号/group_openid 条目生效（用于拼接 UMO）。如果白名单中全部使用完整 UMO 格式，此项无需填写。留空时自动选择对应类型下唯一的活跃实例；存在多个实例时必须明确填写。
 4. `poll_interval_seconds`：默认 300 秒，最低 60 秒。
 5. `sources`：可单独停用任意内置来源。
@@ -82,10 +85,23 @@ OpenAI、Claude、Groq、Cohere、Moonshot AI、MiniMax、GitHub 和 Cloudflare 
 
 ## 命令
 
+### 状态查询
+
 - `/厂商状态`
 - `/vendor_status`
 
 以上命令行为相同：收到指令后立即抓取所有启用来源并返回最新状态总览图，不会修改自动告警的去重或送达状态。命令目前在 aiocqhttp 和 qq_official 平台生效，群聊和私聊均可使用。
+
+### 订阅开关
+
+- `/厂商订阅 开`：开启当前群的厂商状态自动推送——把本群 UMO 写入 `group_whitelist` 并持久化保存，下一轮轮询后开始收到告警。
+- `/厂商订阅 关`：关闭当前群的自动推送——从 `group_whitelist` 移除本群 UMO 并持久化保存，停止向本群推送。
+
+说明：
+- 仅 **Bot 管理员**可在 **群聊** 中使用；非管理员或私聊执行会被拒绝。
+- 参数只识别确切的 `开` / `关`；填写其它内容（含为空）只返回用法提示，不会改动配置。
+- 重复开启/关闭是幂等的，不会重复写盘。
+- 效果与在 WebUI 手动编辑 `group_whitelist` 等价，区别在于该指令直接落盘、重启后保持。
 
 ## 通知规则
 

--- a/main.py
+++ b/main.py
@@ -661,3 +661,63 @@ class GlobalStatusMonitor(star.Star):
             yield event.plain_result(
                 "厂商状态查询失败，请检查 AstrBot 日志和网络配置。"
             )
+
+    def _normalize_group_whitelist(self) -> list[str]:
+        """读取并清洗 group_whitelist；非列表或为空返回 []。"""
+        raw = self.config.get("group_whitelist", [])
+        if not isinstance(raw, list):
+            return []
+        return [str(item).strip() for item in raw if str(item).strip()]
+
+    async def _set_group_subscription(self, umo: str, action: str) -> str:
+        """按确定动作改写当前群 UMO 的订阅状态，并持久化到配置文件。
+
+        action 仅识别 "开" / "关" 两个确切取值；其它任何值一律返回用法，
+        不做推测匹配、不修改配置。
+        """
+        groups = self._normalize_group_whitelist()
+        present = umo in groups
+        token = action.strip()
+
+        if token == "开":
+            if present:
+                return "ℹ️ 当前群组已订阅厂商状态自动推送，无需重复开启。"
+            groups.append(umo)
+        elif token == "关":
+            if not present:
+                return "ℹ️ 当前群组未订阅厂商状态自动推送，无需关闭。"
+            groups.remove(umo)
+        else:
+            return "用法：/厂商订阅 开｜关"
+
+        # 一次调用完成「内存更新 + 落盘」，重启后保持。
+        await self.config.save_config_async({"group_whitelist": groups})
+
+        if token == "开":
+            return (
+                "✅ 已为当前群组开启厂商状态自动订阅，下一轮轮询后开始推送告警。\n"
+                f"当前订阅群组数：{len(groups)}。"
+            )
+        return (
+            "✅ 已为当前群组关闭厂商状态自动订阅，将不再收到主动告警。\n"
+            f"剩余订阅群组数：{len(groups)}。"
+        )
+
+    @filter.command("厂商订阅", alias={"vendor_subscribe"})
+    @filter.platform_adapter_type(
+        filter.PlatformAdapterType.AIOCQHTTP | filter.PlatformAdapterType.QQOFFICIAL
+    )
+    async def vendor_subscribe(self, event: AstrMessageEvent, action: str = ""):
+        """开启/关闭当前群组的厂商状态自动订阅，并持久化到配置文件。
+
+        用法：/厂商订阅 开｜关（参数非法时仅返回用法，不做猜测）。
+        """
+        if not event.is_admin():
+            yield event.plain_result("⚠️ 仅 Bot 管理员可执行此指令。")
+            return
+        umo = event.unified_msg_origin
+        if ":GroupMessage:" not in umo:
+            yield event.plain_result("⚠️ 该指令需在群聊中使用。")
+            return
+        reply = await self._set_group_subscription(umo, action)
+        yield event.plain_result(reply)

--- a/main.py
+++ b/main.py
@@ -664,10 +664,17 @@ class GlobalStatusMonitor(star.Star):
 
     def _normalize_group_whitelist(self) -> list[str]:
         """读取并清洗 group_whitelist；非列表或为空返回 []。"""
-        raw = self.config.get("group_whitelist", [])
-        if not isinstance(raw, list):
-            return []
-        return [str(item).strip() for item in raw if str(item).strip()]
+        return self._configured_groups()
+
+    def _subscription_entries_for_umo(
+        self, groups: list[str], umo: str
+    ) -> list[str]:
+        """Return whitelist entries that resolve to the current unified origin."""
+        return [
+            entry
+            for entry in groups
+            if entry == umo or umo in self._targets([entry]).values()
+        ]
 
     async def _set_group_subscription(self, umo: str, action: str) -> str:
         """按确定动作改写当前群 UMO 的订阅状态，并持久化到配置文件。
@@ -675,20 +682,21 @@ class GlobalStatusMonitor(star.Star):
         action 仅识别 "开" / "关" 两个确切取值；其它任何值一律返回用法，
         不做推测匹配、不修改配置。
         """
-        groups = self._normalize_group_whitelist()
-        present = umo in groups
         token = action.strip()
+        if token not in {"开", "关"}:
+            return "用法：/厂商订阅 开｜关"
+
+        groups = self._normalize_group_whitelist()
+        matching_entries = self._subscription_entries_for_umo(groups, umo)
 
         if token == "开":
-            if present:
+            if matching_entries:
                 return "ℹ️ 当前群组已订阅厂商状态自动推送，无需重复开启。"
             groups.append(umo)
-        elif token == "关":
-            if not present:
-                return "ℹ️ 当前群组未订阅厂商状态自动推送，无需关闭。"
-            groups.remove(umo)
+        elif not matching_entries:
+            return "ℹ️ 当前群组未订阅厂商状态自动推送，无需关闭。"
         else:
-            return "用法：/厂商订阅 开｜关"
+            groups = [entry for entry in groups if entry not in matching_entries]
 
         # 一次调用完成「内存更新 + 落盘」，重启后保持。
         await self.config.save_config_async({"group_whitelist": groups})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,6 +48,16 @@ class DummyContext:
         return self.global_config
 
 
+class DummyConfig(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.saved = []
+
+    async def save_config_async(self, replace_config):
+        self.update(replace_config)
+        self.saved.append(dict(replace_config))
+
+
 def _plugin(config=None, platforms=None):
     instance = GlobalStatusMonitor(
         DummyContext(platforms),
@@ -393,6 +403,70 @@ async def test_vendor_status_command_returns_image_without_mutating_state(monkey
     assert isinstance(responses[0][0], Image)
     assert fetch_count == 1
     assert plugin._state == before
+
+
+@pytest.mark.asyncio
+async def test_group_subscription_closes_plain_group_id(monkeypatch):
+    config = DummyConfig(
+        {"enabled": True, "group_whitelist": ["100"], "platform_id": ""}
+    )
+    plugin = _plugin(config)
+
+    reply = await plugin._set_group_subscription("1:GroupMessage:100", "关")
+
+    assert config["group_whitelist"] == []
+    assert config.saved == [{"group_whitelist": []}]
+    assert "已为当前群组关闭" in reply
+
+
+@pytest.mark.asyncio
+async def test_group_subscription_closes_all_matching_whitelist_formats():
+    umo = "1:GroupMessage:100"
+    config = DummyConfig(
+        {
+            "enabled": True,
+            "group_whitelist": ["100", umo, "200", "100"],
+            "platform_id": "",
+        }
+    )
+    plugin = _plugin(config)
+
+    await plugin._set_group_subscription(umo, "关")
+
+    assert config["group_whitelist"] == ["200"]
+    assert config.saved == [{"group_whitelist": ["200"]}]
+
+
+@pytest.mark.asyncio
+async def test_group_subscription_handles_qq_official_group_openid():
+    umo = "qq-instance:GroupMessage:group-openid"
+    config = DummyConfig(
+        {
+            "enabled": True,
+            "platform_type": "qq_official",
+            "group_whitelist": ["group-openid"],
+            "platform_id": "",
+        }
+    )
+    plugin = _plugin(config, platforms=[DummyPlatform("qq-instance", "qq_official")])
+
+    await plugin._set_group_subscription(umo, "关")
+
+    assert config["group_whitelist"] == []
+
+
+@pytest.mark.asyncio
+async def test_group_subscription_invalid_action_does_not_persist():
+    config = DummyConfig(
+        {"enabled": True, "group_whitelist": ["100"], "platform_id": ""}
+    )
+    plugin = _plugin(config)
+
+    reply = await plugin._set_group_subscription("1:GroupMessage:100", "开启")
+
+    assert reply == "用法：/厂商订阅 开｜关"
+    assert config["group_whitelist"] == ["100"]
+    assert config.saved == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- 仅 Bot 管理员可在群聊中使用；参数只识别确切的「开」「关」，其它输入仅返回用法
- 开启时把当前群 UMO 写入 group_whitelist，关闭时移除，均通过 save_config_async 落盘
- 监控循环每轮重新读取 group_whitelist，无需重启即可在下一轮生效